### PR TITLE
Fix broken install url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,13 +28,14 @@
 #
 class caddy (
 
-  $install_path  = $caddy::params::install_path,
-  $caddy_user    = $caddy::params::caddy_user,
-  $caddy_group   = $caddy::params::caddy_group,
-  $caddy_log_dir = $caddy::params::caddy_log_dir,
-  $caddy_tmp_dir = $caddy::params::caddy_tmp_dir,
+  $install_path      = $caddy::params::install_path,
+  $caddy_user        = $caddy::params::caddy_user,
+  $caddy_group       = $caddy::params::caddy_group,
+  $caddy_log_dir     = $caddy::params::caddy_log_dir,
+  $caddy_tmp_dir     = $caddy::params::caddy_tmp_dir,
 
-  $caddy_features = 'git,mailout,ipfilter',
+  $caddy_features    = 'git,mailout,ipfilter',
+  $caddy_install_url = 'https://caddyserver.com/download/linux',
 
   )inherits caddy::params{
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class caddy (
   $caddy_log_dir     = $caddy::params::caddy_log_dir,
   $caddy_tmp_dir     = $caddy::params::caddy_tmp_dir,
 
-  $caddy_features    = 'git,mailout,ipfilter',
+  $caddy_features    = 'http.git,http.mailout,http.ipfilter',
   $caddy_install_url = 'https://caddyserver.com/download/linux',
 
   )inherits caddy::params{

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,7 +12,7 @@ class caddy::package inherits caddy {
   $caddy_url    ="${caddy_install_url}/${$caddy::params::arch}?plugins=${caddy::caddy_features}"
   $caddy_dl_dir ="-o ${caddy::params::caddy_tmp_dir}/caddy_linux_${$caddy::params::arch}_custom.tar.gz"
 
-  notice{$caddy_url: }
+  notify{$caddy_url: }
 
   exec { 'install caddy':
     command => "curl ${caddy_dl_dir} ${caddy_url}",

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,6 +12,8 @@ class caddy::package inherits caddy {
   $caddy_url    ="${caddy_install_url}/${$caddy::params::arch}?plugins=${caddy::caddy_features}"
   $caddy_dl_dir ="-o ${caddy::params::caddy_tmp_dir}/caddy_linux_${$caddy::params::arch}_custom.tar.gz"
 
+  notice{$caddy_url: }
+
   exec { 'install caddy':
     command => "curl ${caddy_dl_dir} ${caddy_url}",
     creates => "${caddy::install_path}/caddy",

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,8 +12,6 @@ class caddy::package inherits caddy {
   $caddy_url    ="${caddy_install_url}/${$caddy::params::arch}?plugins=${caddy::caddy_features}"
   $caddy_dl_dir ="-o ${caddy::params::caddy_tmp_dir}/caddy_linux_${$caddy::params::arch}_custom.tar.gz"
 
-  notify{$caddy_url: }
-
   exec { 'install caddy':
     command => "curl ${caddy_dl_dir} ${caddy_url}",
     creates => "${caddy::install_path}/caddy",

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -9,7 +9,7 @@ class caddy::package inherits caddy {
     path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
   }
 
-  $caddy_url    ="https://caddyserver.com/download/build?os=linux\\&arch=${$caddy::params::arch}\\&features=${caddy::caddy_features}"
+  $caddy_url    ="${caddy_install_url}/${$caddy::params::arch}?plugins=${caddy::caddy_features}"
   $caddy_dl_dir ="-o ${caddy::params::caddy_tmp_dir}/caddy_linux_${$caddy::params::arch}_custom.tar.gz"
 
   exec { 'install caddy':


### PR DESCRIPTION
caddy has new names for all plugins (formerly features), and also a new uri-scheme for binaries

* fix install source url
* fix default plugin names
* enable override of install url